### PR TITLE
NearFieldCorrection: fix unit scale of lambda

### DIFF
--- a/mmwave/dsp/compensation.py
+++ b/mmwave/dsp/compensation.py
@@ -159,7 +159,14 @@ def near_field_correction(idx,
         None. azimuth_output is changed in-place.
     """
 
-    LAMBDA_77GHz_MILLIMETER = 3e8 / 77e9
+    # From the mmwave sdk 02.01.00.04 : #define MMWDEMO_XWR16XX_EVM_77GHZ_LAMBDA       (3.8961)
+    #    All length units are in mm. The LAMBDA (wavelength) below is based on 77 GHz
+    #    and corresponds to the actual spacing on the EVM, it is not
+    #    tied to the actual start frequency set in profile config, hence does not
+    #    need to be computed on the fly from that configuration.
+    # lambda = c / f = 3e8 m/s / 77e9 Hz = 0.0038961 m -> in millimeter: 3.8961 mm as above
+    # As all calculations here are meant to be calculated in millimeters, we have to scale lambda accordingly!
+    LAMBDA_77GHz_MILLIMETER = (3e8 / 77e9) * 1000.0
     MMWDEMO_TWO_PI_OVER_LAMBDA = 2.0 * math.pi / LAMBDA_77GHz_MILLIMETER
 
     # Sanity check and check if nearFieldCorrection is necessary.


### PR DESCRIPTION
This fixes the unit scale of LAMBDA_77GHz_MILLIMETER which is currently meters instead of millimeters.
All other calculation already assume millimeters, i.e. the range https://github.com/PreSenseRadar/OpenRadar/blob/65bcd6287af31685acf8b0c32f4505e0f6faab94/mmwave/dsp/compensation.py#L201
or the geometry point offsets for point D of 8.7mm: https://github.com/PreSenseRadar/OpenRadar/blob/65bcd6287af31685acf8b0c32f4505e0f6faab94/mmwave/dsp/compensation.py#L190
Hence, lambda should be scaled to millimeters as well to avoid adding variables with different unit scales.