### PR TITLE
Update angle_estimation.py

### DIFF
--- a/mmwave/dsp/angle_estimation.py
+++ b/mmwave/dsp/angle_estimation.py
@@ -526,7 +526,7 @@ def gen_steering_vec(ang_est_range, ang_est_resolution, num_ant):
             real = np.cos(mag)
             imag = np.sin(mag)
 
-            steering_vectors[kk, jj] = np.complex(real, imag)
+            steering_vectors[kk, jj] = np.complex64(real + 1j*imag)
 
     return [num_vec, steering_vectors]
 


### PR DESCRIPTION
The numpy array 'steering_vectors' will now be populated with np.complex64 instead of np.complex which was depreciated in numpy 1.20.