### PR TITLE
Read raw data with int16 rather than uint16

### DIFF
--- a/demo/visualizer/main.py
+++ b/demo/visualizer/main.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
 
     # (1) Reading in adc data
     if loadData:
-        adc_data = np.fromfile('./data/1_person_walking_128loops.bin', dtype=np.uint16)
+        adc_data = np.fromfile('./data/1_person_walking_128loops.bin', dtype=np.int16)
         adc_data = adc_data.reshape(numFrames, -1)
         adc_data = np.apply_along_axis(DCA1000.organize, 1, adc_data, num_chirps=numChirpsPerFrame,
                                        num_rx=numRxAntennas, num_samples=numADCSamples)


### PR DESCRIPTION
Acoording to the official TI MATLAB code, mmWaveStudio/MatlabExamples/singlechip_raw_data_reader_example/rawDataReader.m:266-269, the format of ADC data is int16 rather than uint16